### PR TITLE
fix(page): hydration mismatch on userId initialization

### DIFF
--- a/ws-sessions-frontend/app/page.js
+++ b/ws-sessions-frontend/app/page.js
@@ -8,14 +8,7 @@ import WebsocketConnector from "./Components/WebsocketConnector";
 
 export default function Home() {
   const [ws, setWs] = useState();
-  const [userId, setUserId] = useState(() => {
-    if (typeof window === "undefined") return undefined;
-    const stored = sessionStorage.getItem("userId");
-    if (stored) return stored;
-    const randomId = uuidv4();
-    sessionStorage.setItem("userId", randomId);
-    return randomId;
-  });
+  const [userId, setUserId] = useState();
   const [isConnected, setIsConnected] = useState(false);
   const [isReading, setIsReading] = useState(false);
   const [chars, setChars] = useState([]);
@@ -51,6 +44,26 @@ export default function Home() {
       };
     }
   };
+
+  // Initialize userId from sessionStorage on the client only. We deliberately
+  // set state inside an effect (instead of useState's lazy initializer) so
+  // that the initial render matches between the build-time static render
+  // (output: "export") and client hydration -- both start with userId ===
+  // undefined. A lazy initializer that reads sessionStorage during render
+  // returns undefined at build time but a UUID on first client render,
+  // causing a hydration mismatch.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    const storedUserId = sessionStorage.getItem("userId");
+    if (!storedUserId) {
+      const randomId = uuidv4();
+      sessionStorage.setItem("userId", randomId);
+      setUserId(randomId);
+    } else {
+      setUserId(storedUserId);
+    }
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const onReadClick = useCallback(() => {
     setIsReading(true);


### PR DESCRIPTION
## Bug

#49 replaced the userId-init `useEffect` with a `useState()` lazy initializer that reads `sessionStorage` during render. That returns `undefined` at build time (no `window`/`sessionStorage` during the static export build), but a UUID on the first client render — so React 19 flags a hydration mismatch on **every page load**:

```
Hydration failed because the server rendered text didn't match the client.
...
  <b className="text-xl">
+   3794b225-df7c-4cdf-850a-bbfbfb02902c
-   
```

Reproduces against `npm run dev` on a stock checkout of main.

## Fix

Restore the `useEffect`-based initialization, which is the canonical SSR-safe pattern for this case: server and client both render with `userId === undefined`, then the effect runs on the client only and populates state with the stored or freshly generated UUID.

Behaviour is identical to the pre-#49 code. The only addition is a scoped `/* eslint-disable react-hooks/set-state-in-effect */` block with a comment explaining why the rule's recommended fix (lazy initializer) is not safe here.

## Verification

- `npx eslint app/` → exit 0, no errors.
- `npm run dev` + reload → no hydration warning, header populates with userId.