### PR TITLE
chore(backend): modernize runtime, DDB billing, security

### DIFF
--- a/handlers/onDisconnect/app.py
+++ b/handlers/onDisconnect/app.py
@@ -30,15 +30,23 @@ def deactivate_user_connection(connection_id):
             ':c': {'S': connection_id}
         }
     )
-    
+
     print(json.dumps(response))
+
+    items = response['Items']
+    if not items:
+        # The connection record may have already been removed by the
+        # OnDelete sweep (which evicts entries idle for more than 5
+        # minutes). In that case there is nothing to deactivate.
+        print(f'No connection record found for connectionId={connection_id}; nothing to deactivate')
+        return
 
     timestamp = int(time.time())
 
     ddb.update_item(
         TableName=table_name,
         Key={
-            'userId': {'S': response['Items'][0]['userId']['S']},
+            'userId': {'S': items[0]['userId']['S']},
         },
         UpdateExpression="set active = :r, lastSeen = :t",
         ExpressionAttributeValues={

--- a/handlers/teleprinter/requirements.txt
+++ b/handlers/teleprinter/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.32.3

--- a/template.yml
+++ b/template.yml
@@ -10,9 +10,13 @@ Description: >
   
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.13
+    Architectures:
+      - arm64
     MemorySize: 128
     Timeout: 15
+    LoggingConfig:
+      LogFormat: JSON
 
 Parameters:
   ApiStageName:
@@ -97,6 +101,7 @@ Resources:
   ConnectionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
       - AttributeName: "userId"
         AttributeType: "S"
@@ -113,41 +118,30 @@ Resources:
       - IndexName: connectionId-index
         Projection:
           ProjectionType: ALL
-        ProvisionedThroughput:
-          WriteCapacityUnits: 5
-          ReadCapacityUnits: 5
         KeySchema:
         - KeyType: HASH
           AttributeName: connectionId
       - IndexName: lastSeen-index
         Projection:
           ProjectionType: KEYS_ONLY
-        ProvisionedThroughput:
-          WriteCapacityUnits: 5
-          ReadCapacityUnits: 5
         KeySchema:
         - KeyType: HASH
           AttributeName: active
         - KeyType: RANGE
           AttributeName: lastSeen
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
       SSESpecification:
         SSEEnabled: True
 
   SessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
       - AttributeName: "userId"
         AttributeType: "S"
       KeySchema:
       - AttributeName: "userId"
         KeyType: "HASH"
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
       SSESpecification:
         SSEEnabled: True
 
@@ -156,7 +150,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: python3.9
       CodeUri: handlers/onDelete/
       MemorySize: 128
       Environment:
@@ -172,7 +165,7 @@ Resources:
         Schedule:
           Type: ScheduleV2
           Properties:
-            ScheduleExpression: rate(5 minute)
+            ScheduleExpression: rate(5 minutes)
 
 ##### Lambda functions #####
   OnConnectFunction:
@@ -188,12 +181,11 @@ Resources:
           TableName: !Ref ConnectionsTable
   OnConnectPermission:
     Type: AWS::Lambda::Permission
-    DependsOn:
-      - Websocket
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref OnConnectFunction
       Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${Websocket}/*'
   OnDisconnectFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -207,12 +199,11 @@ Resources:
           TableName: !Ref ConnectionsTable
   OnDisconnectPermission:
     Type: AWS::Lambda::Permission
-    DependsOn:
-      - Websocket
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref OnDisconnectFunction
       Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${Websocket}/*'
   
   TeleprinterFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Single PR addressing the backend audit findings.

## CRITICAL
- **Lambda runtime python3.9 → python3.13.** Python 3.9 reached end of support on 2025-11-06; AWS Lambda already blocks creating new functions on 3.9, and blocks function updates from 2026-04. A fresh `sam deploy` on this stack would fail today.

## HIGH
- **EventBridge Scheduler `rate(5 minute)` → `rate(5 minutes)`.** Per AWS docs, the unit must be plural for values > 1; the singular form is technically invalid syntax.

## MEDIUM
- **DynamoDB → `BillingMode: PAY_PER_REQUEST`.** Tables and GSIs were on `ProvisionedThroughput: 5/5`. The sample is bursty/idle and provisioned mode bills even at zero traffic. On-demand is also the modern SAM/CDK default.
- **`Architectures: [arm64]`** added to `Globals.Function`. Graviton is ~20% cheaper than x86_64 with no code changes for pure-Python.
- **`LoggingConfig.LogFormat: JSON`** added to `Globals.Function`. Structured CloudWatch logs filter much better.

## LOW
- **Pin `requests==2.32.3`** in `handlers/teleprinter/requirements.txt` (was unpinned → non-reproducible builds).
- **`OnConnect`/`OnDisconnect` `Lambda::Permission` now scope `SourceArn`** to the Websocket API. Previously any principal in `apigateway.amazonaws.com` could invoke these functions. The `TeleprinterPermission` already had this; aligning the other two. Dropped the now-redundant `DependsOn: Websocket` (the `!Sub` on `${Websocket}` in `SourceArn` creates the same implicit dependency; cfn-lint W3005 confirmed).
- **`handlers/onDisconnect`: guard against empty `Items`** in the connectionId-index query. Previously `response['Items'][0]` threw `IndexError` when the connection record had already been removed by the OnDelete sweep (connections idle > 5 min). Now logs and returns cleanly.

## Verified locally
- `cfn-lint template.yml` → exit 0, no findings.
- `python3 -m py_compile` on the modified handler succeeds.
- The CI gate is `cfn-nag`; the new `SourceArn` is exactly what cfn-nag flags missing.

## Out of scope (separate PRs)
- **Issue #13** — Sec-WebSocket-Protocol header abuse for userId. Architectural change touching frontend + Lambda authorizer.
- The `print(json.dumps(event))` debug prints that leak userId via the `Sec-WebSocket-Protocol` header in CloudWatch — tied to #13.
- Lambda Powertools migration / structured logging library — bigger change, low ROI for a sample.